### PR TITLE
Add shared DB support and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 2025/04/24 コメント欄を追加&PDF出力にもコメント欄を追加 <br>
 2025/04/25 テストデータ入力の名前入力欄にオートコンプリート機能を追加<br>
 2025/05/08 グラフにZ統計量から算出したスコアを表示するように更新
+
+## Database Configuration
+
+This application now expects database files on a shared network drive. Set the
+`SHARED_DB_DIR` environment variable to the directory containing
+`id_database.db` and `physical_rawdata.db`. If the variable is not provided,
+`/mnt/shared` is used by default.


### PR DESCRIPTION
## Summary
- load SQLite files from `SHARED_DB_DIR` with default `/mnt/shared`
- clean duplicate imports

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68468893b2f0832297e70c6b94f8e251